### PR TITLE
fix: do not overwrite truthy matchesIgnore

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,18 +77,9 @@ module.exports = () => {
           })
 
           let diff = semver.diff(currentVersion, latestVersion)
-
-          let matchesIgnore
-          if (options.ignore.length > 0) {
-            options.ignore.forEach((pattern) => {
-              matchesIgnore = moduleKey.match(pattern)
-            })
-          }
-          if (options.ignoreRegex.length > 0) {
-            options.ignoreRegex.forEach((pattern) => {
-              matchesIgnore = moduleKey.match(pattern)
-            })
-          }
+          const { ignore = [], ignoreRegex = [] } = options
+          const matchesIgnore = ignore.includes(moduleKey)
+            || ignoreRegex.some(pattern => moduleKey.match(pattern))
 
           if (matchesIgnore) {
             diff = 'ignored'


### PR DESCRIPTION
When having more then one value for ignore / ignoreRegex the last value decides if the module should be ignored.

tested with local .check-node-modules.config.json
`{
    "ignore": ["yargs", "chalk"],
    "ignoreRegex": [".*ar[gk]", ".*ab+"]
}`

and the module yargs is currently out of date for me